### PR TITLE
feat: restore deepin patches on upower

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+upower (1.90.9-1deepin1) unstable; urgency=medium
+
+  * Restore deepin/uniontech patches: Patch: uniontech-not-action.patch
+    Description: Disable upower's critical power action to allow
+    external control.
+
+ -- lichenggang <lichenggang@uniontech.com>  Tue, 21 Jul 2026 20:57:52 +0800
+
 upower (1.90.9-1) unstable; urgency=medium
 
   * New upstream version 1.90.9

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+uniontech-not-action.patch

--- a/debian/patches/uniontech-not-action.patch
+++ b/debian/patches/uniontech-not-action.patch
@@ -1,0 +1,20 @@
+--- a/etc/UPower.conf	2026-07-21 20:56:01.418031866 +0800
++++ b/etc/UPower.conf	2026-07-21 20:56:01.423031961 +0800
+@@ -64,7 +64,7 @@
+ # PercentageAction=2.0
+ PercentageLow=20.0
+ PercentageCritical=5.0
+-PercentageAction=2.0
++PercentageAction=0
+ 
+ # When UsePercentageForPolicy is false, the time remaining in seconds at
+ # which UPower will consider the battery low, critical, or take action for
+@@ -79,7 +79,7 @@
+ # TimeAction=120
+ TimeLow=1200
+ TimeCritical=300
+-TimeAction=120
++TimeAction=10
+ 
+ # Enable the risky CriticalPowerAction-Suspend
+ # This option is not recommended, but it is here for users who


### PR DESCRIPTION
Restore deepin-specific patches from master branch:
  - uniontech-not-action.patch: Disable upower's critical power action to allow external control.

Related: automated backport of deepin patches.